### PR TITLE
chore: migrate renovate.json to .renovaterc.json

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": ["*"],
+      "automerge": true,
+      "automergeType": "branch",
+      "automergeStrategy": "fast-forward",
+      "requiredStatusChecks": null
+    }
+  ],
+  "platformAutomerge": true
+}


### PR DESCRIPTION
Migrating Renovate configuration to .renovaterc.json format while keeping the same configuration content.